### PR TITLE
Tweak pixel plot: more distinction between  pipeline and transit centers

### DIFF
--- a/src/contaminante/contaminante.py
+++ b/src/contaminante/contaminante.py
@@ -567,8 +567,8 @@ def _make_plot(tpf, res):
                 np.hstack(res["contaminator_ra"]),
                 np.hstack(res["contaminator_dec"]),
                 c="r",
-                marker=".",
-                s=13,
+                marker="+",
+                s=40,
                 label="Center of Transit Pixels",
                 zorder=10,
             )


### PR DESCRIPTION
At times it is hard to distinguish between the blue dot and red dot (pipeline center and transit center), especially for people who have some color blind issue.

This PR changes the red dot to red "+":

![image](https://user-images.githubusercontent.com/250644/161361388-caf94e1b-2252-46a2-b545-3d8f438a2dd8.png)
